### PR TITLE
fix/unit-test-workflow-for-forks

### DIFF
--- a/.github/workflows/notify-unit-test.yml
+++ b/.github/workflows/notify-unit-test.yml
@@ -1,0 +1,11 @@
+# handles fork builds that needs secrets
+name: Notify unit test
+
+on: [pull_request]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: notifying unit-test workflow
+        run: echo 'done'

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,13 +1,23 @@
 name: unit-test
 
-on: [pull_request]
+on:
+  workflow_run:
+    workflows: ["Notify unit test"]
+    types:
+      - completed
 
 jobs:
-  test:
+  unit-test:
     runs-on: ubuntu-latest
     steps:
+      # adds a way to have this workflow reflect on the pull request
+      - uses: haya14busa/action-workflow_run-status@v1
+
       - name: checkout
         uses: actions/checkout@v2
+        with:
+          # checkouts the commit that triggered the Notify unit test workflow
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: cached dependencies
         uses: actions/cache@v2


### PR DESCRIPTION
This handles the permissions issue of the composer action setup when fork repos triggers the workflow. I added 2 workflows which does the following
- `notify-unit-test` workflow which only does is to consume the workflow trigger that came from pull requests
- `unit-test` workflow which waits for `notify-unit-test` workflow to finish before running the unit test workflow.

I've also updated the `unit-test` workflow to add a workflow status tracker for the pull request since workflows that were triggered by the `workflow_run` event doesn't show up in the pull requests.

After this PR has been merged, it's better to add the workflows as status checks in the repository's settings.